### PR TITLE
Add 'event-model' group to maintainers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @cjh1
+* @cjh1 @conda-forge/event-model

--- a/README.md
+++ b/README.md
@@ -152,4 +152,5 @@ Feedstock Maintainers
 =====================
 
 * [@cjh1](https://github.com/cjh1/)
+* [@conda-forge/event-model](https://github.com/conda-forge/event-model/)
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -124,3 +124,4 @@ about:
 extra:
   recipe-maintainers:
     - cjh1
+    - conda-forge/event-model


### PR DESCRIPTION
This PR is to add NSLS-II contingent to the list of maintainers. Similar to https://github.com/conda-forge/bluesky-feedstock/blob/5222051a915defe3bbe418859a6b7184094202d8/recipe/meta.yaml#L62.