### PR TITLE
Include itk-elastix in tomviz packaging

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -50,3 +50,11 @@ if errorlevel 1 exit 1
 
 cmake --build . --target install --config Release
 if errorlevel 1 exit 1
+
+:: Install itk-elastix.
+:: We'll include it in our package since it is not available on conda-forge.
+:: The latest ITK on conda-forge is 5.1.2, so install the latest
+:: itk-elastix that uses ITK 5.1.2, which is 0.9.0.
+set ITK_ELASTIX_WHL_URL=https://files.pythonhosted.org/packages/e3/15/7b727429e86967428f7354dc24022543086243720e9f7302ff94a3d741b3/itk_elastix-0.9.0-cp37-cp37m-win_amd64.whl
+pip install --no-deps %ITK_ELASTIX_WHL_URL%
+if errorlevel 1 exit 1

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -44,3 +44,16 @@ cmake -G"Ninja" -DCMAKE_BUILD_TYPE:STRING=Release \
   -DPython3_ROOT_DIR:PATH=${PREFIX} \
   ../tomviz
 ninja install -j${CPU_COUNT}
+
+
+# Install itk-elastix. We'll include it in our package since it is not
+# available on conda-forge.
+# The latest ITK on conda-forge is 5.1.2, so install the latest
+# itk-elastix that uses ITK 5.1.2, which is 0.9.0.
+if [ `uname` == Darwin ]; then
+  ITK_ELASTIX_WHL_URL=https://files.pythonhosted.org/packages/46/a1/24311db277ce6432ac2c799fe77a01c5151a5b4376f15d088b7c265cc36f/itk_elastix-0.9.0-cp37-cp37m-macosx_10_9_x86_64.whl
+elif [ `uname` == Linux ]; then
+  ITK_ELASTIX_WHL_URL=https://files.pythonhosted.org/packages/48/a2/c93146a9f7c60026323b668dd0b12546afdff77f1dc14ecd75e0bbd95bb8/itk_elastix-0.9.0-cp37-cp37m-manylinux1_x86_64.whl
+fi
+
+pip install --no-deps $ITK_ELASTIX_WHL_URL

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,6 +42,10 @@ build:
 
 requirements:
   build:
+    - python
+    - pip
+    - wheel
+    - setuptools
     - cmake
     - ninja
     - pkg-config


### PR DESCRIPTION
We want to include `itk-elastix` as a dependency to tomviz, but it is
not available on conda-forge.

However, it is available on pip, it is small, and it was designed to
work in conda environments (similar to ITK). Thus, we can `pip install`
it and include it in our tomviz package.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
